### PR TITLE
fix: change bundling to support linked libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ before_script:
 branches:
   only:
     - master
-cache:
-  directories:
-  - node_modules
 notifications:
   email:
     on_success: never

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,6 @@ environment:
     - nodejs_version: '6'
     - nodejs_version: '4'
 
-cache:
-  - node_modules
-
 install:
   - ps: Install-Product node $env:nodejs_version x64
   - set CI=true

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "eslint-plugin-flowtype-errors": "2.0.2",
     "flow-bin": "0.37.4",
     "husky": "0.11.9",
+    "rimraf": "2.5.4",
     "xo": "0.17.1"
   },
   "dependencies": {

--- a/source/create-bundler/index.js
+++ b/source/create-bundler/index.js
@@ -23,10 +23,8 @@ function createBundler(options: BrowserifyOptions, context: BundleContext): Bund
 		if (file in cache) {
 			return cache[file];
 		}
-		if (file.includes('node_modules')) {
-			return original(file, id, pkg);
-		}
-		throw new Error(`Could not resolve ${file} as ${id} from ${context.file.path}`);
+
+		return original(file, id, pkg);
 	};
 
 	bundler._mdeps.readFile = readFile.bind(bundler._mdeps);

--- a/test/fakes.js
+++ b/test/fakes.js
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import rimraf from 'rimraf';
+
+export function createFakeDir() {
+	fs.mkdirSync('fakes');
+}
+
+export function createFakeModule() {
+	fs.mkdirSync('node_modules/fake-module');
+	fs.writeFileSync('node_modules/fake-module/index.js', 'const test = true;\n');
+}
+
+export function createLinkedFakeModule() {
+	fs.mkdirSync('fakes/link-dest');
+	fs.writeFileSync('fakes/link-dest/index.js', 'const test = true;\n');
+	fs.linkSync('fakes/link-dest', 'node_modules/linked-fake-module');
+}
+
+export function cleanUpFakes() {
+	rimraf.sync('fakes');
+	rimraf.sync('node_modules/fake-module');
+	rimraf.sync('node_modules/linked-fake-module');
+}

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -22,6 +22,18 @@ export const emptyFile = getFile({
 	dependencies: {}
 });
 
+export const fileWithModuleDeps = getFile({
+	buffer: 'require(\'fake-module\');',
+	path: 'fakes/index.js',
+	dependencies: {}
+});
+
+export const fileWithLinkedModuleDeps = getFile({
+	buffer: 'require(\'linked-fake-module\');',
+	path: 'fakes/index.js',
+	dependencies: {}
+});
+
 export const emptyBufferFile = getFile({
 	buffer: new Buffer(''),
 	path: 'empty/index.js',

--- a/test/test-index.js
+++ b/test/test-index.js
@@ -3,6 +3,15 @@
 import test from 'ava';
 import factory from '../source';
 import * as mocks from './mocks';
+import {createFakeDir, createFakeModule, createLinkedFakeModule, cleanUpFakes} from './fakes';
+
+test.before('create fake directory', () => {
+	createFakeDir();
+});
+
+test.after.always('clean up fakes', () => {
+	cleanUpFakes();
+});
 
 test('it should export a function as default', t => {
 	const actual = typeof factory;
@@ -40,4 +49,16 @@ test('the resolved object should have a buffer key for buffer files', async t =>
 	const transform = factory(mocks.application);
 	const file = await transform(mocks.emptyBufferFile);
 	t.truthy(Object.prototype.hasOwnProperty.call(file, 'buffer'));
+});
+
+test('load module dependencies', async () => {
+	createFakeModule();
+	const transform = factory(mocks.application);
+	await transform(mocks.fileWithModuleDeps);
+});
+
+test('load linked module dependencies', async () => {
+	createLinkedFakeModule();
+	const transform = factory(mocks.application);
+	await transform(mocks.fileWithLinkedModuleDeps);
 });


### PR DESCRIPTION
2d9c3377511686ecdade8362e3bbf667433aa132 introduced a check that throws if a file is neither in the cache nor contains 'node_modules' in its filename. This results in the bundler throwing on linked dependencies.

This PR removes the check on the filename. If a file can't be resolved patternplate-server won't exit anymore but should still log out errors.